### PR TITLE
Correct the license reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ some reserved characters incorrectly escaped by net/url (see [issue 5684](https:
 
 ## License
 
-MIT
+Go license (BSD-3-Clause)
 


### PR DESCRIPTION
It is not the MIT license, but rather the BSD-3-Clause license for Google Inc.
