### PR TITLE
 Add poweron architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
-
+arch:
+   - ppc64le
+   - amd64
 go:
   - 1.4.x
   - 1.5.x
@@ -7,6 +9,11 @@ go:
   - 1.7.x
   - 1.8.x
   - tip
+jobs:
+  exclude :
+    - arch : ppc64le
+      go :
+       - 1.4.x 
 
 install:
   - go build .


### PR DESCRIPTION
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing, For more info please tag @gerrith3.
